### PR TITLE
Extending Command Manager window

### DIFF
--- a/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
@@ -83,7 +83,7 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
 	}
 
 	public void deleteObservers() {
-		commandManager.getChangePublisher().clearObservers();
+		commandManager.deleteCurrentObservers();
 		this.updateObserverListField();
 	}
 

--- a/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
@@ -22,6 +22,7 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
 
 	private String observerListString;
 	private JTextArea observerListField;
+	private JButton btnRunCommand;
 
 	/**
 	 * 
@@ -37,60 +38,55 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
 		this.commandManager = commandManager;
 
 		GridBagConstraints c = new GridBagConstraints();
-
-		observerListField = new JTextArea("");
-		observerListField.setEditable(false);
 		c.fill = GridBagConstraints.BOTH;
 		c.weightx = 1;
 		c.gridx = 0;
 		c.weighty = 1;
+
+		observerListField = new JTextArea("");
+		observerListField.setEditable(false);
 		content.add(observerListField, c);
 		updateObserverListField();
 
 		currentCommandField = new JTextArea("");
 		currentCommandField.setEditable(false);
-		c.fill = GridBagConstraints.BOTH;
-		c.weightx = 1;
-		c.gridx = 0;
-		c.weighty = 1;
 		content.add(currentCommandField, c);
 		updateCurrentCommandField();
 
 		JButton btnClearCommand = new JButton("Clear command");
-		btnClearCommand.addActionListener((ActionEvent e) -> this.clearCommand());
-		c.fill = GridBagConstraints.BOTH;
-		c.weightx = 1;
-		c.gridx = 0;
-		c.weighty = 1;
+
+		btnClearCommand.addActionListener((ActionEvent e) -> {
+			this.clearCommand();
+			btnRunCommand.setEnabled(false);
+		});
+
 		content.add(btnClearCommand, c);
 
-		JButton btnRunCommand = new JButton("Run command");
+		btnRunCommand = new JButton("Run command");
+		btnRunCommand.setEnabled(false);
 		btnRunCommand.addActionListener((ActionEvent e) -> this.runCommand());
-		c.fill = GridBagConstraints.BOTH;
-		c.weightx = 1;
-		c.gridx = 0;
-		c.weighty = 1;
 		content.add(btnRunCommand, c);
 
 		JButton btnClearObservers = new JButton("Delete observers");
 		JButton btnResetObservers = new JButton("Reset observers");
 		btnResetObservers.setEnabled(false);
+
 		btnResetObservers.addActionListener(e -> {
 			this.resetObservers();
 			btnClearObservers.setEnabled(true);
 			btnResetObservers.setEnabled(false);
 		});
+
 		btnClearObservers.addActionListener((ActionEvent e) -> {
 			this.deleteObservers();
 			btnClearObservers.setEnabled(false);
 			btnResetObservers.setEnabled(true);
 		});
-		c.fill = GridBagConstraints.BOTH;
-		c.weightx = 1;
-		c.gridx = 0;
-		c.weighty = 1;
+
 		content.add(btnClearObservers, c);
 		content.add(btnResetObservers, c);
+
+		this.commandManager.addObserver(() -> btnRunCommand.setEnabled(true));
 	}
 
 	private void clearCommand() {

--- a/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
@@ -87,6 +87,21 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
 		this.updateObserverListField();
 	}
 
+	/**
+	 * Invokes method of <code>DriverCommandManager</code> that runs stored command, if set.
+	 */
+	public void runCommand(){
+		commandManager.runCurrentCommand();
+	}
+
+	/**
+	 * Restores observers from cache of <code>DriverCommandManager</code>.
+	 */
+	public void resetObservers(){
+		commandManager.resetObservers();
+		this.updateObserverListField();
+	}
+
 	private void updateObserverListField() {
 		observerListString = "";
 		List<Subscriber> commandChangeSubscribers = commandManager.getChangePublisher().getSubscribers();

--- a/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
@@ -64,13 +64,33 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
 		c.weighty = 1;
 		content.add(btnClearCommand, c);
 
+		JButton btnRunCommand = new JButton("Run command");
+		btnRunCommand.addActionListener((ActionEvent e) -> this.runCommand());
+		c.fill = GridBagConstraints.BOTH;
+		c.weightx = 1;
+		c.gridx = 0;
+		c.weighty = 1;
+		content.add(btnRunCommand, c);
+
 		JButton btnClearObservers = new JButton("Delete observers");
-		btnClearObservers.addActionListener((ActionEvent e) -> this.deleteObservers());
+		JButton btnResetObservers = new JButton("Reset observers");
+		btnResetObservers.setEnabled(false);
+		btnResetObservers.addActionListener(e -> {
+			this.resetObservers();
+			btnClearObservers.setEnabled(true);
+			btnResetObservers.setEnabled(false);
+		});
+		btnClearObservers.addActionListener((ActionEvent e) -> {
+			this.deleteObservers();
+			btnClearObservers.setEnabled(false);
+			btnResetObservers.setEnabled(true);
+		});
 		c.fill = GridBagConstraints.BOTH;
 		c.weightx = 1;
 		c.gridx = 0;
 		c.weighty = 1;
 		content.add(btnClearObservers, c);
+		content.add(btnResetObservers, c);
 	}
 
 	private void clearCommand() {

--- a/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
@@ -22,7 +22,6 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
 
 	private String observerListString;
 	private JTextArea observerListField;
-	private JButton btnRunCommand;
 
 	/**
 	 * 
@@ -54,6 +53,7 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
 		updateCurrentCommandField();
 
 		JButton btnClearCommand = new JButton("Clear command");
+		JButton btnRunCommand = new JButton("Run command");
 
 		btnClearCommand.addActionListener((ActionEvent e) -> {
 			this.clearCommand();
@@ -62,7 +62,6 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
 
 		content.add(btnClearCommand, c);
 
-		btnRunCommand = new JButton("Run command");
 		btnRunCommand.setEnabled(false);
 		btnRunCommand.addActionListener((ActionEvent e) -> this.runCommand());
 		content.add(btnRunCommand, c);

--- a/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/gui/CommandManagerWindow.java
@@ -85,7 +85,7 @@ public class CommandManagerWindow extends JFrame implements WindowComponent {
 		content.add(btnClearObservers, c);
 		content.add(btnResetObservers, c);
 
-		this.commandManager.addObserver(() -> btnRunCommand.setEnabled(true));
+		this.commandManager.getChangePublisher().addSubscriber(() -> btnRunCommand.setEnabled(true));
 	}
 
 	private void clearCommand() {

--- a/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
@@ -7,6 +7,8 @@ import edu.kis.powp.jobs2d.command.ICompoundCommand;
 import edu.kis.powp.observer.Publisher;
 import edu.kis.powp.observer.Subscriber;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -16,6 +18,8 @@ public class DriverCommandManager {
 	private DriverCommand currentCommand = null;
 
 	private Publisher changePublisher = new Publisher();
+
+	private Collection<Subscriber> cache = null;
 
 	/**
 	 * Set current command.
@@ -71,7 +75,12 @@ public class DriverCommandManager {
 	 */
 
 	public synchronized void deleteCurrentObservers(){
+		
+		if(changePublisher.getSubscribers().size() > 0){
+			cache = new ArrayList<>(changePublisher.getSubscribers());
+		}
 
+		changePublisher.clearObservers();
 	}
 
 	/**

--- a/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
@@ -2,8 +2,7 @@ package edu.kis.powp.jobs2d.command.manager;
 
 import edu.kis.powp.jobs2d.command.DefaultCompoundCommand;
 import edu.kis.powp.jobs2d.command.DriverCommand;
-import edu.kis.powp.jobs2d.command.DriverCommandVisitor;
-import edu.kis.powp.jobs2d.command.ICompoundCommand;
+import edu.kis.powp.jobs2d.drivers.DriverManager;
 import edu.kis.powp.observer.Publisher;
 import edu.kis.powp.observer.Subscriber;
 
@@ -18,11 +17,19 @@ public class DriverCommandManager {
 	private DriverCommand currentCommand = null;
 
 	private Publisher changePublisher = new Publisher();
-
+	private DriverManager driverManager;
 	private Collection<Subscriber> cache = null;
 
 	/**
-	 * Set current command.
+	 * Constructor of driver command manager, I had to choose whether keep accessing static method of DriverFeature or assign reference only one time
+	 * @param driverManager
+	 */
+	public DriverCommandManager(DriverManager driverManager) {
+		this.driverManager = driverManager;
+	}
+
+	/**
+	 * Sets current command.
 	 *
 	 * @param commandList list of commands representing a compound command.
 	 * @param name        name of the command.
@@ -32,7 +39,7 @@ public class DriverCommandManager {
 	}
 
 	/**
-	 * Return current command.
+	 * Returns current command.
 	 *
 	 * @return Current command.
 	 */
@@ -41,7 +48,7 @@ public class DriverCommandManager {
 	}
 
 	/**
-	 * Set current command.
+	 * Sets current command.
 	 *
 	 * @param commandList Set the command as current.
 	 */
@@ -62,16 +69,18 @@ public class DriverCommandManager {
 	}
 
 	/**
-	 * Run current command, if set.
+	 * Runs current command, if set.
 	 *
 	 */
 
 	public synchronized void runCurrentCommand(){
-
+		if(currentCommand != null){
+			currentCommand.execute(driverManager.getCurrentDriver());
+		}
 	}
 
 	/**
-	 * Delete observers and move observers collection to cache
+	 * Deletes observers and move observers collection to cache
 	 */
 
 	public synchronized void deleteCurrentObservers(){

--- a/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
@@ -56,6 +56,33 @@ public class DriverCommandManager {
 			return getCurrentCommand().toString();
 	}
 
+	/**
+	 * Run current command, if set.
+	 *
+	 */
+
+	public synchronized void runCurrentCommand(){
+
+	}
+
+	/**
+	 * Delete observers and move observers collection to cache
+	 */
+
+	public synchronized void deleteCurrentObservers(){
+
+	}
+
+	/**
+	 * Restores observers from cache
+	 * NOTE:
+	 * It's probable if addObserver/s feature would be implemented, the cache should be empty
+	 */
+
+	public synchronized void resetObservers(){
+
+	}
+
 	public Publisher getChangePublisher() {
 		return changePublisher;
 	}

--- a/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
@@ -75,7 +75,7 @@ public class DriverCommandManager {
 	 */
 
 	public synchronized void deleteCurrentObservers(){
-		
+
 		if(changePublisher.getSubscribers().size() > 0){
 			cache = new ArrayList<>(changePublisher.getSubscribers());
 		}
@@ -90,7 +90,11 @@ public class DriverCommandManager {
 	 */
 
 	public synchronized void resetObservers(){
-
+		if(cache != null && cache.size() > 0){
+			cache.forEach(cached -> changePublisher.addSubscriber(cached));
+			cache.clear();
+			cache = null;
+		}
 	}
 
 	/**
@@ -99,7 +103,14 @@ public class DriverCommandManager {
 	 * @param subscriber new observer to add.
 	 */
 	public synchronized void addObserver(Subscriber subscriber){
+		if(subscriber != null){
+			changePublisher.addSubscriber(subscriber);
 
+			if(cache != null && cache.size() > 0){
+				cache.clear();
+				cache = null;
+			}
+		}
 	}
 
 	/**

--- a/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
@@ -92,8 +92,7 @@ public class DriverCommandManager {
 	public synchronized void resetObservers(){
 		if(cache != null && cache.size() > 0){
 			cache.forEach(cached -> changePublisher.addSubscriber(cached));
-			cache.clear();
-			cache = null;
+			clearCache();
 		}
 	}
 
@@ -105,11 +104,17 @@ public class DriverCommandManager {
 	public synchronized void addObserver(Subscriber subscriber){
 		if(subscriber != null){
 			changePublisher.addSubscriber(subscriber);
+		}
+	}
 
-			if(cache != null && cache.size() > 0){
-				cache.clear();
-				cache = null;
-			}
+
+	/**
+	 * Clears any stored cache in DriverCommandManager.
+	 */
+	public synchronized void clearCache(){
+		if(cache != null && cache.size() > 0){
+			cache.clear();
+			cache = null;
 		}
 	}
 
@@ -118,7 +123,16 @@ public class DriverCommandManager {
 	 * @param subscribers list to append.
 	 */
 	public synchronized void addObservers(List<Subscriber> subscribers){
+		if(subscribers != null){
 
+			subscribers.forEach(subscriber -> {
+				if(subscriber != null){
+					changePublisher.addSubscriber(subscriber);
+				}
+			});
+
+			clearCache();
+		}
 	}
 
 	public Publisher getChangePublisher() {

--- a/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
@@ -7,7 +7,6 @@ import edu.kis.powp.observer.Publisher;
 import edu.kis.powp.observer.Subscriber;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -18,7 +17,7 @@ public class DriverCommandManager {
 
 	private Publisher changePublisher = new Publisher();
 	private DriverManager driverManager;
-	private Collection<Subscriber> cache = null;
+	private List<Subscriber> cache = null;
 
 	/**
 	 * Constructor of driver command manager, I had to choose whether keep accessing static method of DriverFeature or assign reference only one time
@@ -99,23 +98,8 @@ public class DriverCommandManager {
 	 */
 
 	public synchronized void resetObservers(){
-		if(cache != null && cache.size() > 0){
-			cache.forEach(cached -> changePublisher.addSubscriber(cached));
-			clearCache();
-		}
+		addObservers(cache);
 	}
-
-	/**
-	 * Add new observer for list of subscribers that belongs to <code>changePublisher</code>
-	 * It should clear cache, if exists.
-	 * @param subscriber new observer to add.
-	 */
-	public synchronized void addObserver(Subscriber subscriber){
-		if(subscriber != null){
-			changePublisher.addSubscriber(subscriber);
-		}
-	}
-
 
 	/**
 	 * Clears any stored cache in DriverCommandManager.
@@ -128,7 +112,7 @@ public class DriverCommandManager {
 	}
 
 	/**
-	 * Add observers to existing collection of subscribers.
+	 * Add observers to existing collection of subscribers. Clears cache.
 	 * @param subscribers list to append.
 	 */
 	public synchronized void addObservers(List<Subscriber> subscribers){

--- a/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
+++ b/src/main/java/edu/kis/powp/jobs2d/command/manager/DriverCommandManager.java
@@ -5,6 +5,7 @@ import edu.kis.powp.jobs2d.command.DriverCommand;
 import edu.kis.powp.jobs2d.command.DriverCommandVisitor;
 import edu.kis.powp.jobs2d.command.ICompoundCommand;
 import edu.kis.powp.observer.Publisher;
+import edu.kis.powp.observer.Subscriber;
 
 import java.util.List;
 
@@ -80,6 +81,23 @@ public class DriverCommandManager {
 	 */
 
 	public synchronized void resetObservers(){
+
+	}
+
+	/**
+	 * Add new observer for list of subscribers that belongs to <code>changePublisher</code>
+	 * It should clear cache, if exists.
+	 * @param subscriber new observer to add.
+	 */
+	public synchronized void addObserver(Subscriber subscriber){
+
+	}
+
+	/**
+	 * Add observers to existing collection of subscribers.
+	 * @param subscribers list to append.
+	 */
+	public synchronized void addObservers(List<Subscriber> subscribers){
 
 	}
 

--- a/src/main/java/edu/kis/powp/jobs2d/features/CommandsFeature.java
+++ b/src/main/java/edu/kis/powp/jobs2d/features/CommandsFeature.java
@@ -12,7 +12,7 @@ public class CommandsFeature {
 		commandManager = new DriverCommandManager(DriverFeature.getDriverManager());
 
 		LoggerCommandChangeObserver loggerObserver = new LoggerCommandChangeObserver();
-		commandManager.addObserver(loggerObserver);
+		commandManager.getChangePublisher().addSubscriber(loggerObserver);
 	}
 
 	/**

--- a/src/main/java/edu/kis/powp/jobs2d/features/CommandsFeature.java
+++ b/src/main/java/edu/kis/powp/jobs2d/features/CommandsFeature.java
@@ -9,10 +9,10 @@ public class CommandsFeature {
 	private static DriverCommandManager commandManager;
 
 	public static void setupCommandManager() {
-		commandManager = new DriverCommandManager();
+		commandManager = new DriverCommandManager(DriverFeature.getDriverManager());
 
 		LoggerCommandChangeObserver loggerObserver = new LoggerCommandChangeObserver();
-		commandManager.getChangePublisher().addSubscriber(loggerObserver);
+		commandManager.addObserver(loggerObserver);
 	}
 
 	/**

--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dApp.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dApp.java
@@ -46,7 +46,6 @@ public class TestJobs2dApp {
 	private static void setupCommandTests(Application application) {
 		application.addTest("Load secret command", new SelectLoadSecretCommandOptionListener());
 
-		application.addTest("Run command", new SelectRunCurrentCommandOptionListener(DriverFeature.getDriverManager()));
 		application.addTest("DriverCommandVisitor test DriverCommand", new SelectSingleCommandVisitorTestListener());
 		application.addTest("DriverCommandVisitor test ICompoundCommand", new SelectCompoundCommandVisitorTestListener());
 		


### PR DESCRIPTION
* Moved "User Test" -> "Run Command" to Command Manager window.
* Added "Reset Observers" button.
* Implemented all needed behaviour to run these actions invoked by buttons:
   * subscribers are cached when deleted, to perform optional restore.
   * added reference to _DriverManager_ from _DriverFeature_ to _DriverCommandManager_ to get  current driver. 
   * hid (nearly) direct usages of _changePublisher_  

Q to reviewer:
- Would be fine if _changePublisher_ remained completely hidden? I mean, programmer has direct access to modifiable list of subscribers, so he/she could add/remove elements from it without direct call of _addSubscriber()_ method.