### PR TITLE
Fixed suspicious Class issue, added new function

### DIFF
--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dApp.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dApp.java
@@ -11,10 +11,7 @@ import edu.kis.powp.appbase.Application;
 import edu.kis.powp.jobs2d.command.gui.CommandManagerWindow;
 import edu.kis.powp.jobs2d.command.gui.CommandManagerWindowCommandChangeObserver;
 import edu.kis.powp.jobs2d.drivers.adapter.LineDriverAdapter;
-import edu.kis.powp.jobs2d.events.SelectLoadSecretCommandOptionListener;
-import edu.kis.powp.jobs2d.events.SelectRunCurrentCommandOptionListener;
-import edu.kis.powp.jobs2d.events.SelectTestFigure2OptionListener;
-import edu.kis.powp.jobs2d.events.SelectTestFigureOptionListener;
+import edu.kis.powp.jobs2d.events.*;
 import edu.kis.powp.jobs2d.features.CommandsFeature;
 import edu.kis.powp.jobs2d.features.DrawerFeature;
 import edu.kis.powp.jobs2d.features.DriverFeature;
@@ -44,7 +41,7 @@ public class TestJobs2dApp {
 	 */
 	private static void setupCommandTests(Application application) {
 		application.addTest("Load secret command", new SelectLoadSecretCommandOptionListener());
-
+		application.addTest("Test command", new SelectLoadTestCommand());
 		application.addTest("Run command", new SelectRunCurrentCommandOptionListener(DriverFeature.getDriverManager()));
 
 	}

--- a/src/test/java/edu/kis/powp/jobs2d/events/SelectLoadTestCommand.java
+++ b/src/test/java/edu/kis/powp/jobs2d/events/SelectLoadTestCommand.java
@@ -1,0 +1,59 @@
+package edu.kis.powp.jobs2d.events;
+
+import edu.kis.powp.jobs2d.command.DriverCommand;
+import edu.kis.powp.jobs2d.command.OperateToCommand;
+import edu.kis.powp.jobs2d.command.SetPositionCommand;
+import edu.kis.powp.jobs2d.command.manager.DriverCommandManager;
+import edu.kis.powp.jobs2d.features.CommandsFeature;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SelectLoadTestCommand implements ActionListener
+{
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        List<DriverCommand> commands = new ArrayList<DriverCommand>();
+        commands.add(new SetPositionCommand(-180, -40));
+        commands.add(new OperateToCommand(-180, 50));
+        commands.add(new SetPositionCommand(-180, -40));
+        commands.add(new OperateToCommand(-140, -40));
+        commands.add(new SetPositionCommand(-140, -40));
+        commands.add(new OperateToCommand(-140, 0));
+        commands.add(new SetPositionCommand(-140, 0));
+        commands.add(new OperateToCommand(-180, 0));
+
+        commands.add(new SetPositionCommand(-50, -30));
+        commands.add(new OperateToCommand(-50, -40));
+        commands.add(new SetPositionCommand(-50, -40));
+        commands.add(new OperateToCommand(-110, -40));
+        commands.add(new SetPositionCommand(-110, -40));
+        commands.add(new OperateToCommand(-110, 50));
+        commands.add(new SetPositionCommand(-110, 50));
+        commands.add(new OperateToCommand(-50, 50));
+        commands.add(new SetPositionCommand(-50, 50));
+        commands.add(new OperateToCommand(-50, 5));
+        commands.add(new SetPositionCommand(-50, 5));
+        commands.add(new OperateToCommand(-80, 5));
+
+        commands.add(new SetPositionCommand(50, -40));
+        commands.add(new OperateToCommand(50, 50));
+        commands.add(new SetPositionCommand(50, -40));
+        commands.add(new OperateToCommand(90, -40));
+        commands.add(new SetPositionCommand(50, -40));
+        commands.add(new OperateToCommand(10, -40));
+
+        commands.add(new SetPositionCommand(110, 50));
+        commands.add(new OperateToCommand(110, -40));
+        commands.add(new SetPositionCommand(110, -40));
+        commands.add(new OperateToCommand(140, 0));
+        commands.add(new SetPositionCommand(140, 0));
+        commands.add(new OperateToCommand(170, -40));
+        commands.add(new SetPositionCommand(170, -40));
+        commands.add(new OperateToCommand(170, 50));
+        DriverCommandManager manager = CommandsFeature.getDriverCommandManager();
+        manager.setCurrentCommand(commands, "TestCommand");
+    }
+}


### PR DESCRIPTION
Added SelectClearMacro class to event package, which causes MacroAdapter driver to forget previously saved command
